### PR TITLE
set some compile time defaults on OS+Architecture

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -34,6 +34,19 @@ impl ToString for OperationSystem {
     }
 }
 
+impl Default for OperationSystem {
+    fn default() -> Self {
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+            { OperationSystem::Darwin }
+
+        #[cfg(target_os = "linux")]
+            { OperationSystem::Linux }
+
+        #[cfg(target_os = "windows")]
+            { OperationSystem::Windows }
+    }
+}
+
 /// The cpu architectures enum
 #[derive(Debug, PartialEq)]
 pub enum Architecture {
@@ -67,6 +80,25 @@ impl ToString for Architecture {
                 "ppc64le".to_string()
             }
         }
+    }
+}
+
+impl Default for Architecture {
+    fn default() -> Self {
+        #[cfg(not(any(target_arch = "x86", target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64")))]
+            { Architecture::Amd64 }
+
+        #[cfg(target_arch = "x86")]
+            { Architecture::I386 }
+
+        #[cfg(target_arch = "arm")]
+            { Architecture::Arm32v7 }
+
+        #[cfg(target_arch = "aarch64")]
+            { Architecture::Arm64v8 }
+
+        #[cfg(target_arch = "powerpc64")]
+            { Architecture::Ppc64le }
     }
 }
 
@@ -108,10 +140,8 @@ impl Default for FetchSettings {
     fn default() -> Self {
         FetchSettings {
             host: "https://repo1.maven.org".to_string(),
-            operating_system:
-            OperationSystem::Darwin,
-            architecture:
-            Architecture::Amd64,
+            operating_system: OperationSystem::default(),
+            architecture: Architecture::default(),
             version: PG_V13,
         }
     }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -17,10 +17,8 @@ pub async fn setup() -> Result<PgEmbed, PgEmbedError> {
         migration_dir: None,
     };
     let fetch_settings = FetchSettings{
-        host: "https://repo1.maven.org".to_string(),
-        operating_system: OperationSystem::Darwin,
-        architecture: Architecture::Amd64,
-        version: PG_V13
+        version: PG_V13,
+        ..Default::default()
     };
     let pg = PgEmbed::new(pg_settings, fetch_settings);
     pg.setup().await?;


### PR DESCRIPTION
This sets some compile time defaults for OS + Architecture so that library works out of the box in more cases without having to configure `FetchSettings`.

Please note Alpine Linux would still have to be configured manually as I only used the most basic conditional compilation directives, but maybe we could also use [`target_env`](https://doc.rust-lang.org/reference/conditional-compilation.html#target_env).