### PR TITLE
fix compilation on linux

### DIFF
--- a/src/command_executor.rs
+++ b/src/command_executor.rs
@@ -166,7 +166,7 @@ where
         }
     }
 
-    #[cfg(any(target_os = "unix", target_os = "macos"))]
+    #[cfg(not(target_os = "windows"))]
     async fn command_execution(&mut self) -> Result<S, E> {
         let (sender, receiver) = tokio::sync::mpsc::channel::<LogOutputData>(1000);
         let res = self.run_process().await;


### PR DESCRIPTION
latest release broke compilation on linux (`target_os = "unix"` does not work, it should be `target_family = "unix"` or `target_os=  "linux"`, but doing this way is more error proof)