### PR TITLE
Problem: can't use pg_embed with anyhow::Error

### DIFF
--- a/src/command_executor.rs
+++ b/src/command_executor.rs
@@ -39,7 +39,7 @@ where
     /// process error type
     fn error_type(&self) -> E;
     /// wrap error
-    fn wrap_error<F: Error + Send + 'static>(&self, error: F, message: Option<String>) -> E;
+    fn wrap_error<F: Error + Sync + Send + 'static>(&self, error: F, message: Option<String>) -> E;
 }
 
 ///

--- a/src/pg_enums.rs
+++ b/src/pg_enums.rs
@@ -96,7 +96,7 @@ impl ProcessStatus<PgServerStatus, PgEmbedError> for PgProcessType {
         }
     }
 
-    fn wrap_error<E: Error + Send + 'static>(
+    fn wrap_error<E: Error + Sync + Send + 'static>(
         &self,
         error: E,
         message: Option<String>,

--- a/src/pg_errors.rs
+++ b/src/pg_errors.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub struct PgEmbedError {
     pub error_type: PgEmbedErrorType,
-    pub source: Option<Box<dyn Error + Send>>,
+    pub source: Option<Box<dyn Error + Sync + Send>>,
     pub message: Option<String>,
 }
 


### PR DESCRIPTION
It fails to compile with:

```
`(dyn std::error::Error + Send + 'static)` cannot be shared between threads safely
```

Solution: add Sync requirement

anyhow is a popular crate, especially for end users of APIs (such as tests and CLIs) and working with it is a useful property to have.