### PR TITLE
removes terminal spawn on windows

### DIFF
--- a/src/command_executor.rs
+++ b/src/command_executor.rs
@@ -13,6 +13,8 @@ use tokio::process::Child;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::Duration;
 
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 ///
 /// Output logging type
 ///
@@ -118,6 +120,8 @@ where
     {
         let mut command = tokio::process::Command::new(executable_path);
         command.args(args);
+        #[cfg(target_os = "windows")]
+        command.creation_flags(CREATE_NO_WINDOW);
         command
     }
 


### PR DESCRIPTION
When using `pg-embed` with other crates such as Tauri, `pg_ctl.exe` spawns a window when the executor is called. This commit adds code to prevent that extra terminal from spawning.