### PR TITLE
Add compile time check for windows and use a different executable path

### DIFF
--- a/src/pg_access.rs
+++ b/src/pg_access.rs
@@ -72,6 +72,9 @@ impl PgAccess {
         pg_ctl.push("bin/pg_ctl");
         // initdb executable
         let mut init_db = cache_dir.clone();
+        #[cfg(target_os = "windows")]
+        init_db.push("bin/initdb.exe");
+        #[cfg(not(target_os = "windows"))]
         init_db.push("bin/initdb");
         // postgres zip file
         let mut zip_file_path = cache_dir.clone();


### PR DESCRIPTION
This fixes 2 issues I had on windows:
1. The caching would not properly work and it would download the excutables every time `setup()` was called.
2. The `init_db()` function would get called on subsequent `setup()` calls due to this logic:

```rs
// postgres.rs:119
pub async fn setup(&mut self) -> PgResult<()> {
    self.pg_access.maybe_acquire_postgres().await?;
    self.pg_access
        .create_password_file(self.pg_settings.password.as_bytes())
        .await?;
    if self.pg_access.db_files_exist().await? { // <- This function returns always false  on windows
        let mut server_status = self.server_status.lock().await;
        *server_status = PgServerStatus::Initialized;
    } else {
        let _r = &self.init_db().await?;
    }
    Ok(())
}

// pg_access.rs:185
pub async fn db_files_exist(&self) -> PgResult<bool> {
    Ok(self.pg_executables_cached().await? // <- This always returns false as it checks for `initdb` instead of `initdb.exe` on windows
        && Self::path_exists(self.pg_version_file.as_path()).await?)
}
```